### PR TITLE
重写 msg-tool 编码支持

### DIFF
--- a/src/core/msgtool_processor.py
+++ b/src/core/msgtool_processor.py
@@ -49,6 +49,25 @@ class MsgToolProcessor:
         """获取支持的引擎列表"""
         return self.executor.get_supported_engines()
     
+    def get_encodings(self) -> list:
+        """获取支持的编码列表"""
+        return self.executor.get_encodings()
+    
+    def get_patched_encodings(self) -> list:
+        """获取支持的注入编码列表"""
+        return self.executor.get_patched_encodings()
+
+    def get_code_page(self, encoding: str) -> Optional[int]:
+        """根据编码名称获取对应的代码页
+        
+        Args:
+            encoding: 编码名称
+            
+        Returns:
+            对应的代码页，找不到时返回None
+        """
+        return self.executor.get_code_page(encoding)
+    
     def get_tool_info(self) -> Dict[str, Any]:
         """获取工具信息"""
         info = {
@@ -76,6 +95,7 @@ class MsgToolProcessor:
         script_folder: str,
         json_folder: str,
         engine: Optional[str] = None,
+        encoding: Optional[str] = None,
         output_callback: Optional[Callable[[str], None]] = None
     ) -> MsgToolProcessResult:
         """提取脚本文本到JSON
@@ -84,6 +104,7 @@ class MsgToolProcessor:
             script_folder: 日文脚本文件夹路径
             json_folder: JSON保存文件夹路径
             engine: 指定的引擎（可选）
+            encoding: 指定的文件编码（可选）
             output_callback: 实时输出回调函数
         
         Returns:
@@ -114,7 +135,7 @@ class MsgToolProcessor:
             
             # 执行提取命令
             result = self.executor.extract(
-                script_folder, json_folder, engine, output_callback
+                script_folder, json_folder, engine, encoding, output_callback
             )
             
             # 分析执行结果
@@ -150,7 +171,8 @@ class MsgToolProcessor:
         json_folder: str,
         output_folder: str,
         engine: Optional[str] = None,
-        use_gbk_encoding: bool = False,
+        encoding: Optional[str] = None,
+        patched_encoding: Optional[str] = None,
         sjis_replacement: bool = False,
         sjis_replace_chars: str = "",
         output_callback: Optional[Callable[[str], None]] = None
@@ -162,7 +184,8 @@ class MsgToolProcessor:
             json_folder: 译文JSON文件夹路径
             output_folder: 输出脚本文件夹路径
             engine: 指定的引擎（可选）
-            use_gbk_encoding: 是否使用GBK编码注入（cp932）
+            encoding: 指定的文件编码（可选）
+            patched_encoding: 指定的注入编码（可选）
             sjis_replacement: 是否启用SJIS替换模式
             sjis_replace_chars: SJIS替换字符
             output_callback: 实时输出回调函数
@@ -220,7 +243,7 @@ class MsgToolProcessor:
             # 执行注入命令
             result = self.executor.inject(
                 script_folder, actual_json_folder, output_folder, 
-                engine, use_gbk_encoding, output_callback
+                engine, encoding, patched_encoding, output_callback
             )
             
             # 检查sjis_ext.bin文件
@@ -264,6 +287,7 @@ class MsgToolProcessor:
         script_folder: str,
         json_folder: str,
         engine: Optional[str] = None,
+        encoding: Optional[str] = None,
         output_callback: Optional[Callable[[str], None]] = None,
         completion_callback: Optional[Callable[[MsgToolProcessResult], None]] = None
     ) -> str:
@@ -273,6 +297,7 @@ class MsgToolProcessor:
             script_folder: 日文脚本文件夹路径
             json_folder: JSON保存文件夹路径
             engine: 指定的引擎（可选）
+            encoding: 指定的文件编码（可选）
             output_callback: 实时输出回调函数
             completion_callback: 完成回调函数
         
@@ -287,7 +312,7 @@ class MsgToolProcessor:
             """在后台线程中执行提取"""
             try:
                 result = self.extract_text(
-                    script_folder, json_folder, engine, output_callback
+                    script_folder, json_folder, engine, encoding, output_callback
                 )
                 if completion_callback:
                     completion_callback(result)
@@ -313,7 +338,8 @@ class MsgToolProcessor:
         json_folder: str,
         output_folder: str,
         engine: Optional[str] = None,
-        use_gbk_encoding: bool = False,
+        encoding: Optional[str] = None,
+        patched_encoding: Optional[str] = None,
         sjis_replacement: bool = False,
         sjis_replace_chars: str = "",
         output_callback: Optional[Callable[[str], None]] = None,
@@ -326,7 +352,8 @@ class MsgToolProcessor:
             json_folder: 译文JSON文件夹路径
             output_folder: 输出脚本文件夹路径
             engine: 指定的引擎（可选）
-            use_gbk_encoding: 是否使用GBK编码注入（cp932）
+            encoding: 指定的文件编码（可选）
+            patched_encoding: 指定的注入编码（可选）
             sjis_replacement: 是否启用SJIS替换模式
             sjis_replace_chars: SJIS替换字符
             output_callback: 实时输出回调函数
@@ -344,7 +371,7 @@ class MsgToolProcessor:
             try:
                 result = self.inject_text(
                     script_folder, json_folder, output_folder,
-                    engine, use_gbk_encoding, sjis_replacement,
+                    engine, encoding, patched_encoding, sjis_replacement,
                     sjis_replace_chars, output_callback
                 )
                 if completion_callback:

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -191,14 +191,22 @@ class Config:
     @msgtool_selected_engine.setter
     def msgtool_selected_engine(self, value: str):
         self.set("MsgToolSettings", "msgtool_selected_engine", value)
+
+    @property
+    def msgtool_encoding(self) -> str:
+        return self.get("MsgToolSettings", "msgtool_encoding", "默认编码")
+
+    @msgtool_encoding.setter
+    def msgtool_encoding(self, value: str):
+        self.set("MsgToolSettings", "msgtool_encoding", value)
     
     @property
-    def msgtool_use_gbk_encoding(self) -> bool:
-        return self.get_bool("MsgToolSettings", "msgtool_use_gbk_encoding")
+    def msgtool_patched_encoding(self) -> str:
+        return self.get("MsgToolSettings", "msgtool_patched_encoding", "默认编码")
     
-    @msgtool_use_gbk_encoding.setter
-    def msgtool_use_gbk_encoding(self, value: bool):
-        self.set_bool("MsgToolSettings", "msgtool_use_gbk_encoding", value)
+    @msgtool_patched_encoding.setter
+    def msgtool_patched_encoding(self, value: str):
+        self.set("MsgToolSettings", "msgtool_patched_encoding", value)
     
     @property
     def msgtool_sjis_replacement(self) -> bool:

--- a/src/utils/msgtool_executor.py
+++ b/src/utils/msgtool_executor.py
@@ -6,6 +6,17 @@ Msg-tool命令执行器
 import os
 from typing import Optional, Callable, List
 from .command_executor import CommandExecutor, ExecutionResult
+from platform import system
+
+
+ENCODING_CP_MAP = {
+    'gb2312': 936,
+    'gbk': 936,
+    'shift-jis': 932,
+    'jis': 932,
+    'cp932': 932,
+    'utf8': 65001,
+}
 
 
 class MsgToolExecutor(CommandExecutor):
@@ -32,6 +43,48 @@ class MsgToolExecutor(CommandExecutor):
             print(f"工具检查: {tool_path} {'not found' if not os.path.exists(tool_path) else 'not executable'}")
         
         return available
+    
+    def get_encodings(self) -> List[str]:
+        """获取支持的编码列表"""
+        encodings = [
+            "默认编码",
+            "gb2312",  # 简体中文
+            "cp932",   # 日文
+            "utf8",    # UTF-8
+            "自动检测（不推荐）"
+        ]
+        return encodings
+    
+    def get_patched_encodings(self) -> List[str]:
+        """获取支持的注入编码列表"""
+        encodings = [
+            "默认编码",
+            "gb2312",  # 简体中文
+            "cp932",   # 日文
+            "utf8",    # UTF-8
+        ]
+        return encodings
+
+    def get_code_page(self, encoding: str) -> Optional[int]:
+        """根据编码名称获取对应的代码页
+        
+        Args:
+            encoding: 编码名称
+            
+        Returns:
+            对应的代码页，找不到时返回None
+        """
+        enc = ENCODING_CP_MAP.get(encoding, None)
+        if enc:
+            return enc
+        encoding = encoding.lower().replace("-", "")
+        enc = ENCODING_CP_MAP.get(encoding, None)
+        if enc:
+            return enc
+        encoding = encoding.strip('cp')
+        if encoding.isdigit():
+            return int(encoding)
+        return None
     
     def get_supported_engines(self) -> List[str]:
         """获取支持的引擎列表
@@ -82,6 +135,7 @@ class MsgToolExecutor(CommandExecutor):
         script_folder: str,
         json_folder: str,
         engine: Optional[str] = None,
+        encoding: Optional[str] = None,
         output_callback: Optional[Callable[[str], None]] = None
     ) -> ExecutionResult:
         """提取脚本到JSON
@@ -90,6 +144,7 @@ class MsgToolExecutor(CommandExecutor):
             script_folder: 日文脚本文件夹路径
             json_folder: JSON保存文件夹路径  
             engine: 指定的引擎类型
+            encoding: 指定的文件编码
             output_callback: 实时输出回调函数
             
         Returns:
@@ -110,6 +165,15 @@ class MsgToolExecutor(CommandExecutor):
         script_type = self._get_script_type_param(engine) if engine else None
         if script_type:
             cmd_parts.extend(["--script-type", script_type])
+
+        # 添加编码参数
+        if encoding and encoding != "默认编码":
+            if encoding == "自动检测（不推荐）":
+                encoding = "auto"
+            if system() == "Windows" and self.get_code_page(encoding):
+                cmd_parts.extend(["--code-page", str(self.get_code_page(encoding))])
+            else:
+                cmd_parts.extend(["--encoding", encoding])
         
         # 添加路径参数
         cmd_parts.extend([script_path, json_path])
@@ -129,7 +193,8 @@ class MsgToolExecutor(CommandExecutor):
         json_folder: str,
         output_folder: str,
         engine: Optional[str] = None,
-        use_gbk_encoding: bool = False,
+        encoding: Optional[str] = None,
+        patched_encoding: Optional[str] = None,
         output_callback: Optional[Callable[[str], None]] = None
     ) -> ExecutionResult:
         """注入JSON回脚本
@@ -139,7 +204,8 @@ class MsgToolExecutor(CommandExecutor):
             json_folder: 译文JSON文件夹路径
             output_folder: 输出脚本文件夹路径
             engine: 指定的引擎类型
-            use_gbk_encoding: 是否使用GBK编码（cp932）
+            encoding: 指定的文件编码
+            patched_encoding: 指定的注入编码
             output_callback: 实时输出回调函数
             
         Returns:
@@ -163,8 +229,19 @@ class MsgToolExecutor(CommandExecutor):
             cmd_parts.extend(["--script-type", script_type])
         
         # 添加编码参数
-        if use_gbk_encoding:
-            cmd_parts.extend(["--encoding", "cp932"])
+        if encoding and encoding != "默认编码":
+            if encoding == "自动检测（不推荐）":
+                encoding = "auto"
+            if system() == "Windows" and self.get_code_page(encoding):
+                cmd_parts.extend(["--code-page", str(self.get_code_page(encoding))])
+            else:
+                cmd_parts.extend(["--encoding", encoding])
+        if patched_encoding and patched_encoding != "默认编码":
+            # Windows 下优先使用Windows API进行字符转换，以避免潜在的Private Use Area字符问题
+            if system() == "Windows" and self.get_code_page(patched_encoding):
+                cmd_parts.extend(["--patched-code-page", str(self.get_code_page(patched_encoding))])
+            else:
+                cmd_parts.extend(["--patched-encoding", patched_encoding])
         
         # 添加路径参数
         cmd_parts.extend([script_path, json_path, output_path])


### PR DESCRIPTION
--encoding/--code-page 是用来控制读取原始脚本时使用的编码
--patched-encoding/--patched-code-page 才是控制注入时使用的编码
<img width="1848" height="368" alt="image" src="https://github.com/user-attachments/assets/03d5861e-2c58-46c6-9657-dac5d7c3de11" />
windows 上支持使用 `cpxxx` 指定任意编码（例如 `cp936`）